### PR TITLE
fix oidc settings to use Drupal standard login

### DIFF
--- a/config/install/oidc.settings.yml
+++ b/config/install/oidc.settings.yml
@@ -1,6 +1,5 @@
-generic_realms:
-  - f8cb678a_a84e_4383_ad6c_75d31b6db120
-login_path: /oidc/login/quanthub_b2c_realm%3Af8cb678a_a84e_4383_ad6c_75d31b6db120
+generic_realms: []
+login_path: null
 redirect_403: false
 disable_user_routes: true
 show_session_expired_message: true


### PR DESCRIPTION
- [x] remove references to invalid realm f8cb678a_a84e_4383_ad6c_75d31b6db120
- [x] use Drupal standard login