### PR TITLE
Fix QuantHubPowerBIEmbedFormatter

### DIFF
--- a/modules/quanthub_core/src/Plugin/Field/FieldFormatter/QuantHubPowerBIEmbedFormatter.php
+++ b/modules/quanthub_core/src/Plugin/Field/FieldFormatter/QuantHubPowerBIEmbedFormatter.php
@@ -136,7 +136,8 @@ class QuantHubPowerBIEmbedFormatter extends FormatterBase {
               'max-age' => $max_age,
             ],
           ];
-        } else {
+        } 
+        else {
           $elements[$delta] = [
             '#markup' => 'Issue generating PowerBi embed token. Please retry later',
             '#cache' => [

--- a/modules/quanthub_core/src/Plugin/Field/FieldFormatter/QuantHubPowerBIEmbedFormatter.php
+++ b/modules/quanthub_core/src/Plugin/Field/FieldFormatter/QuantHubPowerBIEmbedFormatter.php
@@ -136,6 +136,14 @@ class QuantHubPowerBIEmbedFormatter extends FormatterBase {
               'max-age' => $max_age,
             ],
           ];
+        } else {
+          $elements[$delta] = [
+            '#markup' => 'Issue generating PowerBi embed token. Please retry later',
+            '#cache' => [
+              'tags' => ['powerbi_embed:token'],
+              'max-age' => 0,
+            ],
+          ];
         }
       }
     }

--- a/modules/quanthub_core/src/Plugin/Field/FieldFormatter/QuantHubPowerBIEmbedFormatter.php
+++ b/modules/quanthub_core/src/Plugin/Field/FieldFormatter/QuantHubPowerBIEmbedFormatter.php
@@ -99,7 +99,7 @@ class QuantHubPowerBIEmbedFormatter extends FormatterBase {
         if (isset($embed_token)) {
           // @todo Implement DI.
           $expiration = DateTimePlus::createFromFormat('Y-m-d\TH:i:s\Z', $embed_token["expiration"]);
-          $max_age = $expiration->getTimestamp() - (new DateTimePlus())->getTimestamp() - 3;
+          $max_age = $expiration->getTimestamp() - (new DateTimePlus())->getTimestamp() - 15;
           if ($max_age < 0) {
             $max_age = 0;
           }

--- a/modules/quanthub_core/src/Plugin/Field/FieldFormatter/QuantHubPowerBIEmbedFormatter.php
+++ b/modules/quanthub_core/src/Plugin/Field/FieldFormatter/QuantHubPowerBIEmbedFormatter.php
@@ -136,7 +136,7 @@ class QuantHubPowerBIEmbedFormatter extends FormatterBase {
               'max-age' => $max_age,
             ],
           ];
-        } 
+        }
         else {
           $elements[$delta] = [
             '#markup' => 'Issue generating PowerBi embed token. Please retry later',


### PR DESCRIPTION
Generate content with `no cache` for the case when we have no token