### PR TITLE
Extra mapping Quanthub.PortalContentEditor => content_editor

### DIFF
--- a/modules/quanthub_core/src/EventSubscriber/OidcEventsSubscriber.php
+++ b/modules/quanthub_core/src/EventSubscriber/OidcEventsSubscriber.php
@@ -16,7 +16,9 @@ class OidcEventsSubscriber implements EventSubscriberInterface {
   /**
    * Extra roles mapping.
    */
-  const DEFAULT_ROLES = [];
+  const DEFAULT_ROLES = [
+    'Quanthub.PortalContentEditor' => 'content_editor',
+  ];
 
   /**
    * The OpenID Connect session service.


### PR DESCRIPTION
As an security officer I'd like to have possibilities to control Portal's content editors
so that I'd like to assign a special role `Quanthub.PortalContentEditor` in my IdP.

