### PR TITLE
DIAL configuration parameters

### DIFF
--- a/themes/quanthub_tailwindcss/quanthub_tailwindcss.theme
+++ b/themes/quanthub_tailwindcss/quanthub_tailwindcss.theme
@@ -39,8 +39,10 @@ function quanthub_tailwindcss_preprocess_page(array &$variables) {
   $variables['#attached']['drupalSettings']['dataAttributeId'] = getenv('DATASET_EXPLORER_DATA_ATTRIBUTE_ID');
   $variables['#attached']['drupalSettings']['unitsOfMeasureId'] = getenv('UNITS_OF_MEASURE_ATTRIBUTE_ID');
   $variables['#attached']['drupalSettings']['facetsLoadHierarchies'] = getenv('FACETS_LOAD_HIERARCHIES');
-  $variables['#attached']['drupalSettings']['dialChartUrl'] = getenv('DIAL_CHART_URL');
+  $variables['#attached']['drupalSettings']['dialChatUrl'] = getenv('DIAL_CHAT_URL');
   $variables['#attached']['drupalSettings']['dialDefaultModel'] = getenv('DIAL_DEFAULT_MODEL');
+  $variables['#attached']['drupalSettings']['dialSignInProvider'] = getenv('DIAL_SIGN_IN_PROVIDER');
+  $variables['#attached']['drupalSettings']['dialEnabledFeatures'] = getenv('DIAL_ENABLED_FEATURES');
 }
 
 /**


### PR DESCRIPTION
`dialChatUrl` - string, `mandatory` DIAL chat / overlay URL
`dialDefaultModel` - string, `optional` if set - pass as `modelId` to `ChatOverlayOptions `
`dialSignInProvider` - string, `optional` if set - pass as `signInProvider` to `OverlaySignInOptions`
`dialEnabledFeatures` - string of comma-separated values, `optional` if set - overrides internal default `enabledFeatures`
 
  See also
  https://github.com/epam/ai-dial-chat/blob/development/libs/overlay/README.md