### PR TITLE
Add log info about download

### DIFF
--- a/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
+++ b/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
@@ -136,8 +136,8 @@ final class Forwarder extends ControllerBase {
     if (!$this->currentUser->isAnonymous()) {
       $uid = $this->currentUser->id();
       $user = $this->userStorage->load($uid);
-      $context['user'] => $user->getDisplayName();
-      $context['email'] => $user->getEmail();
+      $context['user'] = $user->getDisplayName();
+      $context['email'] = $user->getEmail();
     }
     $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', $context);
   }

--- a/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
+++ b/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
@@ -139,7 +139,7 @@ final class Forwarder extends ControllerBase {
         'user' => $user->getDisplayName(),
         'email' => $user->getEmail(),
       ]);
-    } 
+    }
     else {
       $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', [
         'uri' => $uri,

--- a/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
+++ b/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
@@ -6,7 +6,9 @@ use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\quanthub_core\UserInfo;
+use Drupal\user\UserStorageInterface;
 use Drupal\user\Entity\User;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
@@ -66,7 +68,9 @@ final class Forwarder extends ControllerBase {
       $container->get('psr7.http_foundation_factory'),
       $container->get('logger.factory'),
       $container->get('config.factory'),
-      $container->get('user_info')
+      $container->get('user_info'),
+      $container->get('current_user'),
+      $container->get('entity_type.manager')
     );
   }
 
@@ -79,12 +83,16 @@ final class Forwarder extends ControllerBase {
     LoggerChannelFactoryInterface $logger_factory,
     ConfigFactory $config_factory,
     UserInfo $user_info,
+    AccountProxyInterface $currentUser,
+    EntityTypeManagerInterface $entityTypeManager,
   ) {
     $this->client = $client;
     $this->foundationFactory = $foundation_factory;
     $this->loggerFactory = $logger_factory;
     $this->configFactory = $config_factory;
     $this->userInfo = $user_info;
+    $this->currentUser = $currentUser;
+    $this->userStorage = $entityTypeManager->getStorage('user');
   }
 
   /**
@@ -122,17 +130,16 @@ final class Forwarder extends ControllerBase {
    */
   private function logForwardDownload(Request $request) {
     $uri = $request->query->get('uri');
-    $current_user = \Drupal::currentUser();
     $user = NULL;
-    if (!$current_user->isAnonymous()) {
-      $uid = $current_user->id();
-      $user = User::load($uid);
+    if (!$this->currentUser->isAnonymous()) {
+      $uid = $this->currentUser->id();
+      $user = $this->userStorage->load($uid);
     }
     if ($user) {
       $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', [
         'uri' => $uri,
         'user' => $user->getDisplayName(),
-        'email' => $user->getEmail()
+        'email' => $user->getEmail(),
       ]);
     } else {
       $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', [

--- a/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
+++ b/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
@@ -58,6 +58,8 @@ final class Forwarder extends ControllerBase {
    */
   private $foundationFactory;
 
+  private const DOWNLOAD_SUBMIT_PATH = '/submit';
+
   /**
    * {@inheritdoc}
    */
@@ -117,19 +119,24 @@ final class Forwarder extends ControllerBase {
    *   The response object.
    */
   public function forwardDownload(Request $request): Response {
-    $this->logForwardDownload($request);
+    $this->logForwardDownloadSubmit($request);
     return $this->forwardInternal($request, getenv('SDMX_DOWNLOAD_API_URL'));
   }
 
   /**
-   * Log info about downloads.
+   * Log info about submit of downloads.
    *
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The incoming request.
    */
-  private function logForwardDownload(Request $request) {
+  private function logForwardDownloadSubmit(Request $request) {
+    $uri = $request->query->get('uri');
+    if (!is_string($uri) || !str_ends_with($uri, self::DOWNLOAD_SUBMIT_PATH)) {
+      return;
+    }
+
     $context = [];
-    $context['uri'] = $request->query->get('uri');
+    $context['uri'] = $uri;
     if ($body = $request->getContent()) {
       $context['body'] = $body;
     }

--- a/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
+++ b/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
@@ -7,6 +7,7 @@ use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\quanthub_core\UserInfo;
+use Drupal\user\Entity\User;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
@@ -109,7 +110,35 @@ final class Forwarder extends ControllerBase {
    *   The response object.
    */
   public function forwardDownload(Request $request): Response {
+    $this->logForwardDownload($request);
     return $this->forwardInternal($request, getenv('SDMX_DOWNLOAD_API_URL'));
+  }
+
+  /**
+   * Log info about downloads.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The incoming request.
+   */
+  private function logForwardDownload(Request $request) {
+    $uri = $request->query->get('uri');
+    $current_user = \Drupal::currentUser();
+    $user = NULL;
+    if (!$current_user->isAnonymous()) {
+      $uid = $current_user->id();
+      $user = User::load($uid);
+    }
+    if ($user) {
+      $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', [
+        'uri' => $uri,
+        'user' => $user->getDisplayName(),
+        'email' => $user->getEmail()
+      ]);
+    } else {
+      $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', [
+        'uri' => $uri
+      ]);
+    }
   }
 
   /**

--- a/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
+++ b/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
@@ -127,24 +127,18 @@ final class Forwarder extends ControllerBase {
    *   The incoming request.
    */
   private function logForwardDownload(Request $request) {
-    $uri = $request->query->get('uri');
-    $user = NULL;
+    $context = array();
+    $context['uri'] = $request->query->get('uri');    
+    if ($body = $request->getContent()) {
+      $context['body'] = $body;
+    }    
     if (!$this->currentUser->isAnonymous()) {
       $uid = $this->currentUser->id();
       $user = $this->userStorage->load($uid);
+      $context['user'] => $user->getDisplayName();
+      $context['email'] => $user->getEmail();
     }
-    if ($user) {
-      $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', [
-        'uri' => $uri,
-        'user' => $user->getDisplayName(),
-        'email' => $user->getEmail(),
-      ]);
-    }
-    else {
-      $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', [
-        'uri' => $uri,
-      ]);
-    }
+    $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', $context);
   }
 
   /**

--- a/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
+++ b/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
@@ -8,8 +8,6 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\quanthub_core\UserInfo;
-use Drupal\user\UserStorageInterface;
-use Drupal\user\Entity\User;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
@@ -141,9 +139,10 @@ final class Forwarder extends ControllerBase {
         'user' => $user->getDisplayName(),
         'email' => $user->getEmail(),
       ]);
-    } else {
+    } 
+    else {
       $this->loggerFactory->get('quanthub_sdmx_proxy')->info('forwardDownload', [
-        'uri' => $uri
+        'uri' => $uri,
       ]);
     }
   }

--- a/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
+++ b/modules/quanthub_sdmx_proxy/src/Controller/Forwarder.php
@@ -5,6 +5,7 @@ namespace Drupal\quanthub_sdmx_proxy\Controller;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\quanthub_core\UserInfo;
@@ -127,11 +128,11 @@ final class Forwarder extends ControllerBase {
    *   The incoming request.
    */
   private function logForwardDownload(Request $request) {
-    $context = array();
-    $context['uri'] = $request->query->get('uri');    
+    $context = [];
+    $context['uri'] = $request->query->get('uri');
     if ($body = $request->getContent()) {
       $context['body'] = $body;
-    }    
+    }
     if (!$this->currentUser->isAnonymous()) {
       $uid = $this->currentUser->id();
       $user = $this->userStorage->load($uid);


### PR DESCRIPTION
Universal approach to just log submit info about downloads. Should work with anonymous and real user

```json
{
	"message": "forwardDownload",
	"context": {
		"uri": "/workspaces/default:SwissRe/engine/data/async/submit",
		"body": "{\"_type\":\"SdmxTableDataQueryPlusV2\",\"includeHistory\":\"false\",\"dimensionAtObservation\":\"TIME_PERIOD\",\"messageVersion\":\"2.0.0\",\"outputFormat\":\"EXCEL\",\"viewMode\":\"TIMESERIES_PER_ROW\",\"agencyID\":\"SWRE\",\"resourceID\":\"STANDARD_INSURANCE_DATA\",\"version\":\"2.0.1\",\"columns\":[{\"componentId\":\"FREQUENCY\",\"value\":\"name\",\"header\":\"name\"},{\"componentId\":\"COUNTRY\",\"value\":\"name\",\"header\":\"name\"},{\"componentId\":\"SERIES\",\"value\":\"name\",\"header\":\"name\"},{\"componentId\":\"SOURCE\",\"value\":\"name\",\"header\":\"name\"},{\"componentId\":\"BUSINESS_LINE\",\"value\":\"name\",\"header\":\"name\"}],\"filters\":[{\"componentCode\":\"TIME_PERIOD\",\"operator\":\"ge\",\"value\":\"631152000000\"},{\"componentCode\":\"TIME_PERIOD\",\"operator\":\"le\",\"value\":\"2082844799999\"}],\"headerConfig\":{\"languages\":[\"en\"]},\"limit\":null,\"rows\":[{\"componentId\":\"OBS_VALUE\"}]}",
		"user": "Illya Havsiyevych",
		"email": "Illya_Havsiyevych@epam.com"
	},
	"level": 200,
	"level_name": "INFO",
	"channel": "quanthub_sdmx_proxy",
	"datetime": "2025-06-13T06:45:57.620595+02:00",
	"extra": {
		"referer": "https://quanthub-portals-swiss-re.imf-eid.projects.epam.com/explorer",
		"ip": "10.0.0.205",
		"request_uri": "https://quanthub-portals-swiss-re.imf-eid.projects.epam.com/sdmx-download/workspaces/default:SwissRe/engine/data/async/submit",
		"uid": "77",
		"user": "Illya_Havsiyevych@epam.com"
	}
}
```